### PR TITLE
add command line flags to proxy and risk-advisor

### DIFF
--- a/cmd/proxy/app/constants.go
+++ b/cmd/proxy/app/constants.go
@@ -22,7 +22,7 @@ func init() {
 		Code:     201,
 	})
 	if err != nil {
-		panic(fmt.Sprintf("Initialization error  while marshalling binding response: %v", err))
+		panic(fmt.Sprintf("Initialization error while marshalling binding response: %v", err))
 	}
 
 	bindingResponse = bindingResponseJSON

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -4,34 +4,36 @@ import (
 	"log"
 	"net/http"
 
+	flag "github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/api"
 
 	"github.com/Prytu/risk-advisor/cmd/proxy/app"
 	"github.com/Prytu/risk-advisor/cmd/proxy/app/podprovider"
 	"github.com/Prytu/risk-advisor/cmd/proxy/app/riskadvisorHandler"
+	"github.com/Prytu/risk-advisor/pkg/flags"
 )
 
-// read from somewhere
-const realApiserverURL = "http://localhost:8080"
-const proxyRACommunicationPort = ":9998"
-const proxySchedulerCommunicationPort = ":9999"
-
 func main() {
+	apiserverAddress := flag.String("apiserver", defaults.ApiserverAddress, "Address on which real appisrver runs")
+	raCommunicationPort := flag.String("ra-port", defaults.RACommunicationPort, "Port for communictaion with risk-advisor")
+	schedulerCommunicationPort := flag.String("scheduler-port", defaults.SchedulerCommunicationPort, "Port for communication with scheduler")
+	flag.Parse()
+
 	responseChannel := make(chan api.Binding, 1)
 	errorChannel := make(chan error)
 	podProvider := podprovider.New()
 
 	raHandler := riskadvisorhandler.New(responseChannel, errorChannel, podProvider)
 
-	proxy, err := app.New(realApiserverURL, podProvider, responseChannel, errorChannel)
+	proxy, err := app.New(*apiserverAddress, podProvider, responseChannel, errorChannel)
 	if err != nil {
 		panic(err)
 	}
 
 	log.Printf("Staring proxy with:\n\t- real apiserver URL: %v\n\t- scheduler communication port: %v"+
-		"\n\t- risk-advisor communication port: %v\n", realApiserverURL, proxySchedulerCommunicationPort,
-		proxyRACommunicationPort)
+		"\n\t- risk-advisor communication port: %v\n", *apiserverAddress, *schedulerCommunicationPort,
+		*raCommunicationPort)
 
-	go http.ListenAndServe(proxyRACommunicationPort, raHandler)
-	http.ListenAndServe(proxySchedulerCommunicationPort, proxy)
+	go http.ListenAndServe(":"+*raCommunicationPort, raHandler)
+	http.ListenAndServe(":"+*schedulerCommunicationPort, proxy)
 }

--- a/cmd/riskadvisor/app/server.go
+++ b/cmd/riskadvisor/app/server.go
@@ -38,7 +38,7 @@ func (as *AdviceService) sendAdviceRequest(request *restful.Request, response *r
 		return
 	}
 
-	resp, err := http.Post(as.proxyUrl, "application/json", bytes.NewReader(arJSON))
+	resp, err := http.Post(as.proxyUrl+"/advise", "application/json", bytes.NewReader(arJSON))
 	if err != nil {
 		response.WriteError(http.StatusNotFound, err)
 		return

--- a/cmd/riskadvisor/main.go
+++ b/cmd/riskadvisor/main.go
@@ -4,19 +4,20 @@ import (
 	"log"
 	"net/http"
 
+	flag "github.com/spf13/pflag"
+
 	"github.com/Prytu/risk-advisor/cmd/riskadvisor/app"
+	"github.com/Prytu/risk-advisor/pkg/flags"
 )
 
-// read from somewhere
-const riskAdvisorPort = ":9997"
-const proxyRACommunicationPort = ":9998"
-const proxyURL = "http://localhost" + proxyRACommunicationPort + "/advise"
-
 func main() {
-	// TODO: Ugly, but will be fixed in issue #11
-	riskAdvisor := app.New(proxyURL)
+	proxyAddress := flag.String("proxy", defaults.ProxyAddress, "Address on which proxy runs")
+	port := flag.String("port", defaults.RiskAdvisorUserPort, "Port on which risk-advisors listens for users requests")
+	flag.Parse()
 
-	log.Printf("Starting risk-advisor with:\n\t- port: %v\n\t- proxy URL: %v", riskAdvisorPort, proxyURL)
+	riskAdvisor := app.New(*proxyAddress)
 
-	http.ListenAndServe(riskAdvisorPort, riskAdvisor)
+	log.Printf("Starting risk-advisor with:\n\t- port: %v\n\t- proxy URL: %v", *port, *proxyAddress)
+
+	http.ListenAndServe(":"+*port, riskAdvisor)
 }

--- a/pkg/flags/defaults.go
+++ b/pkg/flags/defaults.go
@@ -1,0 +1,7 @@
+package defaults
+
+const ApiserverAddress = "http://localhost:8080"
+const RACommunicationPort = "9998"
+const SchedulerCommunicationPort = "9999"
+const ProxyAddress = "http://localhost:" + RACommunicationPort
+const RiskAdvisorUserPort = "9997"


### PR DESCRIPTION
fixes #11 

you can now run proxy and risk advisor with different parameters than default ones e.g like that:
_riskadvisor --port 11111 --proxy http://localhost:22222_
_proxy --ra-port 22222 --scheduler-port 33333_

don't forget to run scheduler with a proper 'master' flag: 
_./kube-scheduler --master=http://localhost:33333 --leader-elect
=false --kube-api-content-type application/json_