### PR TITLE
Dockerfiles and image build scripts for simulator and riskadvisor

### DIFF
--- a/docker/riskadvisor/Dockerfile
+++ b/docker/riskadvisor/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+
+COPY riskadvisor /bin/
+
+CMD ["/bin/riskadvisor"]
+
+EXPOSE 9997

--- a/docker/riskadvisor/build.sh
+++ b/docker/riskadvisor/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker build -t riskadvisor . --no-cache

--- a/docker/simulator/Dockerfile
+++ b/docker/simulator/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu
+
+COPY simulator /bin/
+
+CMD ["/bin/simulator"]
+
+EXPOSE 9998 9999

--- a/docker/simulator/build.sh
+++ b/docker/simulator/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo docker build -t simulator . --no-cache


### PR DESCRIPTION
Build scripts require simulator/riskadvisor binaries inside the directory